### PR TITLE
fix: add custom pages directory support for NX or Monorepo solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ type NTRConfig = {
   debug?: boolean
   routesDataFileName?: string
   routesTree?: TRouteBranch<L>
+  pagesDirectory?: string
 }
 ```
 

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -386,13 +386,14 @@ export type NTRConfig = {
   debug?: boolean
   routesDataFileName?: string
   routesTree?: TRouteBranch
+  pagesDirectory?: string
 }
 
 /**
  * Inject translated routes
  */
 export const withTranslateRoutes = ({
-  translateRoutes: { debug, routesDataFileName, routesTree: customRoutesTree } = {},
+  translateRoutes: { debug, routesDataFileName, routesTree: customRoutesTree, pagesDirectory } = {},
   ...nextConfig
 }: NextConfig & { i18n: I18NConfig; translateRoutes: NTRConfig }): NextConfig => {
   if (!nextConfig.i18n) {
@@ -401,7 +402,7 @@ export const withTranslateRoutes = ({
     )
   }
 
-  const pagesDir = ['pages', 'src/pages', 'app/pages', 'intergrations/pages'].find((dirPath) =>
+  const pagesDir = ['pages', 'src/pages', 'app/pages', 'intergrations/pages', pagesDirectory].find((dirPath) =>
     fs.existsSync(pathUtils.join(process.cwd(), dirPath)),
   )
 


### PR DESCRIPTION
# Problem

If your nextjs project is working on NX Monorepo solutions. It cannot work because It's looking hardcoded defined paths like "src/pages", "/pages" etc. but NX Monorepo is using like "apps/<app-name>/src/pages" and It doesn't work. NX running commands are only working on root directory. config.tsx line 406 is using process.cwd and it's not supporting custom pages directory

# Solution

I added "pagesDirectory" config into harcoded paths and It will work now 