### PR TITLE
Updates type of Link component

### DIFF
--- a/src/react/link.tsx
+++ b/src/react/link.tsx
@@ -1,13 +1,18 @@
 import NextLink, { LinkProps } from 'next/link'
 import { useRouter as useNextRouter } from 'next/router'
-import React from 'react'
+import React, { type FC, type AnchorHTMLAttributes, type ReactNode } from 'react'
 
 import { translatePushReplaceArgs } from './translatePushReplaceArgs'
 
 /**
  * Link component that handle route translations
  */
-export const Link: React.FC<React.PropsWithChildren<LinkProps>> = ({ href, as, locale, ...props }) => {
+export const Link: FC<
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> &
+    LinkProps & {
+      children?: ReactNode
+    } & React.RefAttributes<HTMLAnchorElement>
+> = ({ href, as, locale, ...props }) => {
   const router = useNextRouter()
   const translatedArgs = translatePushReplaceArgs({ router, url: href, as, locale })
 


### PR DESCRIPTION
Fixes #62 

Update the type of the Link component, so it can be used as it is meant to be in Next.js.