### PR TITLE
Catch all fix

### DIFF
--- a/src/shared/regex.ts
+++ b/src/shared/regex.ts
@@ -43,7 +43,7 @@ export const optionalMatchAllFilepathPartRegex = /^\[\[\.{3}([^/[\]?#]+)\]\]$/
 /**
  * Match all `[...pathParts]` parts but not `[[...pathParts]]` parts
  */
-export const matchAllFilepathPartsRegex = /\[\.{3}([^/[\]?#]+)\]/g
+export const matchAllFilepathPartsRegex = /\[\.{3}([^/[\]?#]+)\]/y
 
 /**
  * A "spread path part" is either a match-all path part (`[...pathParts]`),
@@ -61,6 +61,14 @@ export const dynamicFilepathPartRegex = /^\[(?!\.{3})([^/[\]?#]*)\]$/
 
 /** Ex: `'[slug]'` => `'slug'` but `'[...pathParts]'` => `null` and '`pathPart'` => `null` */
 export const getDynamicPathPartKey = (pathPart: string) => dynamicFilepathPartRegex.exec(pathPart)?.[1] || null
+
+/** Ex: `[[...pathParts]]` => `'pathParts'` but `'[slug]'` => null and '`pathPart'` => `null` */
+export const getCatchAllPathPartKey = (pathPart: string) => {
+  // We make sure that regex index is reset so we don't miss any match
+  matchAllFilepathPartsRegex.lastIndex = 0
+
+  return matchAllFilepathPartsRegex.exec(pathPart)?.[1] || null
+}
 
 /**
  * Match all `[slug]` parts but neither `[...pathParts]` parts nor `[[...pathParts]]` parts


### PR DESCRIPTION
Currently the Link component does not work well with catch all routes. The problem is that when you click on a link that refers to a route which is part static and part catch all the link leads directly to the specified route but without translating the static part. Example:

Given the following folder structure:
```
pages/
├─ men/
│  ├─ _routes.json
│  ├─ [...categories].tsx
│  ├─ index.tsx
```
And the following `_routes.json`:
```json
{
  "/": {
    "en": "men",
    "es-ES": "hombres"
  }
}

```
And nextjs locale config being:
```
i18n: {
    localeDetection: false,
    locales: ["en", "es-ES"],
    defaultLocale: "es-ES"
  },
```
When clicking on a link whose href is `/men/shoes` I will expect to be redirected to `/hombres/shoes` but this is not the case. The link is taking me to `/men/shoes` and after refreshing the page the url is properly being redirected to `/hombres/shoes`. If I manually type `/men/shoes` on the url and press enter I'm also being properly redirected to `/hombres/shoes` thus I came up with this fix to make sure that the link component is handling catch all routes with static parts properly.

You can reproduce the issue and also try the fix I did in this [codepen](https://codesandbox.io/p/sandbox/next-translate-routes-lpg2gl?file=%2Fcomponents%2FLayout.tsx%3A1%2C1).