### PR TITLE
Remove querystring dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   },
   "dependencies": {
     "path-to-regexp": "^6.2.0",
-    "querystring": "^0.2.1",
-    "typescript": "^4.7.3",
     "url": "^0.11.0",
     "yamljs": "^0.3.0"
   },
@@ -67,6 +65,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.3",
+    "typescript": "^5.3.2",
     "webpack": "^5.65.0",
     "yarn-or-npm": "^3.0.1"
   },

--- a/src/react/enhanceNextRouter.ts
+++ b/src/react/enhanceNextRouter.ts
@@ -1,6 +1,6 @@
 import type { PrefetchOptions } from 'next/dist/shared/lib/router/router'
+import { formatUrl } from 'next/dist/shared/lib/router/utils/format-url'
 import { NextRouter, SingletonRouter } from 'next/router'
-import { stringify as stringifyQuery } from 'querystring'
 
 import { getNtrData } from '../shared/ntrData'
 import { ntrMessagePrefix } from '../shared/withNtrPrefix'
@@ -50,17 +50,7 @@ const enhancePrefetch =
       logWithTrace('router.prefetch', { inputUrl, asPath, options, parsedInputUrl, locale })
     }
 
-    return router.prefetch(
-      parsedInputUrl
-        ? (parsedInputUrl.pathname || '/') +
-            (parsedInputUrl.query &&
-              `?${
-                typeof parsedInputUrl.query === 'string' ? parsedInputUrl.query : stringifyQuery(parsedInputUrl.query)
-              }`)
-        : inputUrl,
-      asPath,
-      options,
-    )
+    return router.prefetch(parsedInputUrl ? formatUrl(parsedInputUrl) : inputUrl, asPath, options)
   }
 
 export const enhanceNextRouter = <R extends NextRouter | SingletonRouter>(router: R) => {

--- a/src/react/fileUrlToFileUrlObject.ts
+++ b/src/react/fileUrlToFileUrlObject.ts
@@ -75,7 +75,7 @@ const getFileUrlObject = ({
       pathParts: remainingPathParts,
     })
 
-    const pathname = `${routeBranch.name ? `/${routeBranch.name}` : ''}${nextPathname}`
+    const pathname = (routeBranch.name ? `/${routeBranch.name}` : '') + nextPathname
     const query =
       isExactMatch || !dynamicPathPartKey
         ? nextQuery

--- a/src/react/parseUrl.ts
+++ b/src/react/parseUrl.ts
@@ -1,8 +1,25 @@
-import { parse as parseQuery } from 'querystring'
-import { parse, UrlObject, UrlWithParsedQuery } from 'url'
+import { ParsedUrl, parseUrl as nextParseUrl } from 'next/dist/shared/lib/router/utils/parse-url'
+import { searchParamsToUrlQuery, urlQueryToSearchParams } from 'next/dist/shared/lib/router/utils/querystring'
+import type { ParsedUrlQuery } from 'querystring'
+import type { UrlObject } from 'url'
 
 /** Parse an url and its query to object */
-export const parseUrl = (url: UrlObject | URL | string) =>
-  typeof url === 'string' || url instanceof URL
-    ? parse(url.toString(), true)
-    : ({ ...url, query: typeof url.query === 'string' ? parseQuery(url.query) : url.query } as UrlWithParsedQuery)
+export const parseUrl = (url: UrlObject | URL | string): ParsedUrl =>
+  typeof url === 'string'
+    ? nextParseUrl(url)
+    : {
+        hash: url.hash || '',
+        hostname: url.hostname,
+        href: url.href || '',
+        pathname: url.pathname || '/',
+        port: url.port?.toString(),
+        protocol: url.protocol,
+        query: searchParamsToUrlQuery(
+          url instanceof URL
+            ? url.searchParams
+            : typeof url.query === 'object' && url.query
+            ? urlQueryToSearchParams(url.query as ParsedUrlQuery)
+            : new URLSearchParams(url.query || undefined),
+        ),
+        search: url.search || '',
+      }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6202,12 +6202,11 @@ __metadata:
     np: ^7.7.0
     path-to-regexp: ^6.2.0
     prettier: ^2.3.2
-    querystring: ^0.2.1
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^3.0.2
     ts-jest: ^27.0.3
-    typescript: ^4.7.3
+    typescript: ^5.3.2
     url: ^0.11.0
     webpack: ^5.65.0
     yamljs: ^0.3.0
@@ -7062,13 +7061,6 @@ __metadata:
   dependencies:
     side-channel: ^1.0.4
   checksum: e812f3c590b2262548647d62f1637b6989cc56656dc960b893fe2098d96e1bd633f36576f4cd7564dfbff9db42e17775884db96d846bebe4f37420d073ecdc0b
-  languageName: node
-  linkType: hard
-
-"querystring@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "querystring@npm:0.2.1"
-  checksum: 7b83b45d641e75fd39cd6625ddfd44e7618e741c61e95281b57bbae8fde0afcc12cf851924559e5cc1ef9baa3b1e06e22b164ea1397d65dd94b801f678d9c8ce
   languageName: node
   linkType: hard
 
@@ -8460,23 +8452,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.3":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "typescript@npm:5.3.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: d92534dda639eb825db013203404c1fabca8ac630564283c9e7dc9e64fd9c9346c2de95ecebdf3e6e8c1c32941bca1cfe0da37877611feb9daf8feeaea58d230
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@^5.3.2#~builtin<compat/typescript>":
+  version: 5.3.2
+  resolution: "typescript@patch:typescript@npm%3A5.3.2#~builtin<compat/typescript>::version=5.3.2&hash=29ae49"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: c034461079fbfde3cb584ddee52afccb15b6e32a0ce186d0b2719968786f7ca73e1b07f71fac4163088790b16811c6ccf79680de190664ef66ff0ba9c1fe4a23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
WIP

Try to remove deprecated querystring dependency and use Next internal utilities.

- Does not work yet.
- Introduce a fragility: if Next moves its utilities around, it will break... Next-translate-routes already plug in Next internals to get RouterContext, which has already led to breakage. Maybe with a stricter next peer dependency...