### PR TITLE
fix: latest next version bug

### DIFF
--- a/src/plugin/checkNextVersion.ts
+++ b/src/plugin/checkNextVersion.ts
@@ -8,7 +8,7 @@ const parseVersion = (version?: string) =>
     ?.map(Number)
 
 type TMinorPatch = `.${number}`
-type TVersion = `${number}` | `${number}${TMinorPatch}` | `${number}${TMinorPatch}${TMinorPatch}`
+type TVersion = `${number}` | `${number}${TMinorPatch}` | `${number}${TMinorPatch}${TMinorPatch}` | 'latest'
 
 export const checkNextVersion = (
   /** Ex: '>=13.3.1', '!=12.2.4' */

--- a/src/plugin/withTranslateRoutes.ts
+++ b/src/plugin/withTranslateRoutes.ts
@@ -56,6 +56,7 @@ export const withTranslateRoutes = (userNextConfig: NextConfigWithNTR): NextConf
   }
 
   const hasOldRouterContextPath = checkNextVersion('<13.5.0')
+  const isLatestNextVersion = checkNextVersion('=latest')
 
   return {
     ...nextConfig,
@@ -75,7 +76,7 @@ export const withTranslateRoutes = (userNextConfig: NextConfigWithNTR): NextConf
       if (!config.plugins) {
         config.plugins = []
       }
-      const ROUTER_CONTEXT_PATH = hasOldRouterContextPath
+      const ROUTER_CONTEXT_PATH = (hasOldRouterContextPath && !isLatestNextVersion)
         ? "'next/dist/shared/lib/router-context'"
         : "'next/dist/shared/lib/router-context.shared-runtime'"
       config.plugins.push(new DefinePlugin({ ROUTER_CONTEXT_PATH }))


### PR DESCRIPTION
I could not use the package without any apparent reason, during further digging I found out an incorrect check of next version, using pnpm, when next version is set to latest the package assumes we have an old router context path, sets it incorrectly and whole app stops working.
Shipping a fix
[package.json](https://github.com/hozana/next-translate-routes/files/14335234/package.json)
